### PR TITLE
[fix] AI 답글 스케줄링을 AFTER_COMMIT 이벤트로 분리하여 댓글 트랜잭션 보호

### DIFF
--- a/src/main/java/com/daramg/server/aicomment/application/AiCommentService.java
+++ b/src/main/java/com/daramg/server/aicomment/application/AiCommentService.java
@@ -145,7 +145,12 @@ public class AiCommentService {
     }
 
     @Transactional
-    public void scheduleReplyForAiComment(Comment aiComment, Post post) {
+    public void scheduleReplyForAiComment(Long aiCommentId, Long postId) {
+        Comment aiComment = commentRepository.findById(aiCommentId).orElse(null);
+        if (aiComment == null) {
+            return;
+        }
+
         if (aiComment.getAiReplyCount() >= MAX_AI_REPLY_COUNT) {
             return;
         }
@@ -157,6 +162,11 @@ public class AiCommentService {
 
         Optional<ComposerPersona> persona = composerPersonaRepository.findByComposerId(composer.getId());
         if (persona.isEmpty() || !persona.get().isActive()) {
+            return;
+        }
+
+        Post post = postRepository.findById(postId).orElse(null);
+        if (post == null) {
             return;
         }
 

--- a/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEvent.java
+++ b/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEvent.java
@@ -1,0 +1,7 @@
+package com.daramg.server.aicomment.event;
+
+public record AiReplyScheduleEvent(
+        Long aiCommentId,
+        Long postId
+) {
+}

--- a/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEventListener.java
+++ b/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEventListener.java
@@ -1,0 +1,26 @@
+package com.daramg.server.aicomment.event;
+
+import com.daramg.server.aicomment.application.AiCommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiReplyScheduleEventListener {
+
+    private final AiCommentService aiCommentService;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleAiReplyScheduleEvent(AiReplyScheduleEvent event) {
+        try {
+            aiCommentService.scheduleReplyForAiComment(event.aiCommentId(), event.postId());
+        } catch (Exception e) {
+            log.warn("AI 답글 잡 등록 실패 - aiCommentId={}, postId={}", event.aiCommentId(), event.postId(), e);
+        }
+    }
+}

--- a/src/main/java/com/daramg/server/comment/application/CommentService.java
+++ b/src/main/java/com/daramg/server/comment/application/CommentService.java
@@ -1,6 +1,6 @@
 package com.daramg.server.comment.application;
 
-import com.daramg.server.aicomment.application.AiCommentService;
+import com.daramg.server.aicomment.event.AiReplyScheduleEvent;
 import com.daramg.server.comment.domain.Comment;
 import com.daramg.server.comment.domain.CommentLike;
 import com.daramg.server.comment.dto.CommentLikeResponseDto;
@@ -30,7 +30,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final AiCommentService aiCommentService;
 
     public void createComment(Long postId, CommentCreateDto request, User user){
         Post post = entityUtils.getEntity(postId, Post.class);
@@ -80,7 +79,7 @@ public class CommentService {
         }
 
         if (parentComment.isAi()) {
-            aiCommentService.scheduleReplyForAiComment(parentComment, post);
+            eventPublisher.publishEvent(new AiReplyScheduleEvent(parentComment.getId(), post.getId()));
         }
     }
 


### PR DESCRIPTION
## Summary
- AI 댓글에 답글 달 때 scheduleReplyForAiComment()를 직접 호출하던 방식 제거
- AiReplyScheduleEvent + AiReplyScheduleEventListener(AFTER_COMMIT) 도입으로 트랜잭션 완전 분리
- 댓글 커밋 성공 후에만 AI 잡 등록 시도, AI 잡 실패가 유저 댓글에 영향 없음
- scheduleReplyForAiComment()를 ID 기반으로 변경하여 detached entity 문제 방지
- CommentService에서 AiCommentService 직접 의존 제거