### PR TITLE
[fix] AiCommentServiceTest 시그니처 변경에 맞게 수정

### DIFF
--- a/src/main/java/com/daramg/server/aicomment/application/AiCommentService.java
+++ b/src/main/java/com/daramg/server/aicomment/application/AiCommentService.java
@@ -145,7 +145,12 @@ public class AiCommentService {
     }
 
     @Transactional
-    public void scheduleReplyForAiComment(Comment aiComment, Post post) {
+    public void scheduleReplyForAiComment(Long aiCommentId, Long postId) {
+        Comment aiComment = commentRepository.findById(aiCommentId).orElse(null);
+        if (aiComment == null) {
+            return;
+        }
+
         if (aiComment.getAiReplyCount() >= MAX_AI_REPLY_COUNT) {
             return;
         }
@@ -157,6 +162,11 @@ public class AiCommentService {
 
         Optional<ComposerPersona> persona = composerPersonaRepository.findByComposerId(composer.getId());
         if (persona.isEmpty() || !persona.get().isActive()) {
+            return;
+        }
+
+        Post post = postRepository.findById(postId).orElse(null);
+        if (post == null) {
             return;
         }
 

--- a/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEvent.java
+++ b/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEvent.java
@@ -1,0 +1,7 @@
+package com.daramg.server.aicomment.event;
+
+public record AiReplyScheduleEvent(
+        Long aiCommentId,
+        Long postId
+) {
+}

--- a/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEventListener.java
+++ b/src/main/java/com/daramg/server/aicomment/event/AiReplyScheduleEventListener.java
@@ -1,0 +1,26 @@
+package com.daramg.server.aicomment.event;
+
+import com.daramg.server.aicomment.application.AiCommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiReplyScheduleEventListener {
+
+    private final AiCommentService aiCommentService;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleAiReplyScheduleEvent(AiReplyScheduleEvent event) {
+        try {
+            aiCommentService.scheduleReplyForAiComment(event.aiCommentId(), event.postId());
+        } catch (Exception e) {
+            log.warn("AI 답글 잡 등록 실패 - aiCommentId={}, postId={}", event.aiCommentId(), event.postId(), e);
+        }
+    }
+}

--- a/src/main/java/com/daramg/server/comment/application/CommentService.java
+++ b/src/main/java/com/daramg/server/comment/application/CommentService.java
@@ -1,6 +1,6 @@
 package com.daramg.server.comment.application;
 
-import com.daramg.server.aicomment.application.AiCommentService;
+import com.daramg.server.aicomment.event.AiReplyScheduleEvent;
 import com.daramg.server.comment.domain.Comment;
 import com.daramg.server.comment.domain.CommentLike;
 import com.daramg.server.comment.dto.CommentLikeResponseDto;
@@ -30,7 +30,6 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final AiCommentService aiCommentService;
 
     public void createComment(Long postId, CommentCreateDto request, User user){
         Post post = entityUtils.getEntity(postId, Post.class);
@@ -80,7 +79,7 @@ public class CommentService {
         }
 
         if (parentComment.isAi()) {
-            aiCommentService.scheduleReplyForAiComment(parentComment, post);
+            eventPublisher.publishEvent(new AiReplyScheduleEvent(parentComment.getId(), post.getId()));
         }
     }
 

--- a/src/test/java/com/daramg/server/aicomment/application/AiCommentServiceTest.java
+++ b/src/test/java/com/daramg/server/aicomment/application/AiCommentServiceTest.java
@@ -220,14 +220,14 @@ public class AiCommentServiceTest extends ServiceTestSupport {
             commentRepository.save(aiComment);
 
             // when
-            aiCommentService.scheduleReplyForAiComment(aiComment, post);
+            aiCommentService.scheduleReplyForAiComment(aiComment.getId(), post.getId());
 
             // then
             List<AiCommentJob> jobs = aiCommentJobRepository.findAll();
             assertThat(jobs).hasSize(1);
             assertThat(jobs.get(0).getTriggerType()).isEqualTo(AiCommentJobTriggerType.USER_REPLY);
             assertThat(jobs.get(0).getParentComment().getId()).isEqualTo(aiComment.getId());
-            assertThat(aiComment.getAiReplyCount()).isEqualTo((byte) 1);
+            assertThat(commentRepository.findById(aiComment.getId()).get().getAiReplyCount()).isEqualTo((byte) 1);
         }
 
         @Test
@@ -240,9 +240,10 @@ public class AiCommentServiceTest extends ServiceTestSupport {
             Comment aiComment = Comment.ofAi(post, botUser, "AI 댓글", null, composer);
             commentRepository.save(aiComment);
             ReflectionTestUtils.setField(aiComment, "aiReplyCount", (byte) 2);
+            commentRepository.save(aiComment);
 
             // when
-            aiCommentService.scheduleReplyForAiComment(aiComment, post);
+            aiCommentService.scheduleReplyForAiComment(aiComment.getId(), post.getId());
 
             // then
             assertThat(aiCommentJobRepository.findAll()).isEmpty();


### PR DESCRIPTION
## Summary
- #130에서 scheduleReplyForAiComment() 시그니처를 ID 기반으로 변경한 것에 맞게 테스트 수정
- aiReplyCount 검증을 DB에서 재조회하는 방식으로 변경